### PR TITLE
Fix infinite loop in ListBundleFormat#createNewField()

### DIFF
--- a/src/main/java/com/addthis/bundle/core/list/ListBundleFormat.java
+++ b/src/main/java/com/addthis/bundle/core/list/ListBundleFormat.java
@@ -84,10 +84,11 @@ public class ListBundleFormat implements BundleFormat {
         while (true) {
             State currentState = state.get();
             int size = currentState.fieldArray.length;
-
-            String name = prefix + size;
-            if (currentState.fieldMap.containsKey(name)) {
-                continue;
+            int accumulate = 0;
+            String name = prefix + (size + accumulate);
+            while (currentState.fieldMap.containsKey(name)) {
+                accumulate++;
+                name = prefix + (size + accumulate);
             }
             Map<String, BundleField> newMap = new HashMap<>(currentState.fieldMap);
             BundleField[] newArray = Arrays.copyOf(currentState.fieldArray, size + 1);

--- a/src/test/java/com/addthis/bundle/core/list/TestListBundleFormat.java
+++ b/src/test/java/com/addthis/bundle/core/list/TestListBundleFormat.java
@@ -47,19 +47,14 @@ public class TestListBundleFormat {
         assertEquals(1, (int) field1.getIndex());
     }
 
-
-    /**
-     * ignoring this test to not break builds as it is unlikely to go off in practice.
-     * Should probably still be fixed. Suggest using some kind of sweet VROW append list.
-     */
-    @Ignore @Test(timeout = 500)
+    @Test
     public void testCreateNewFieldCollision() {
         ListBundleFormat format = new ListBundleFormat();
         BundleField field0 = format.getField("1");
         assertEquals("1", field0.getName());
         assertEquals(0, (int) field0.getIndex());
-        format.createNewField("");
-        //assert previous call will never finish
+        BundleField field1 = format.createNewField("");
+        assertEquals("2", field1.getName());
     }
 
     @Test


### PR DESCRIPTION
I not a fan of the ListBundleFormat#createNewField() method.
It is kind of silly it allows the user to create a field that
is guaranteed to be a new field. There was a pathological case
where this method could encounter an infinite loop. This commit
fixes the infinite loop by incrementing suffix to the next integer.
Technically it is still possible to generate an infinite loop by
creating 2^32 new bundle fields in a bundle but you have other
problems if you are doing this.
